### PR TITLE
update log4j.properties file name

### DIFF
--- a/deploy/flink-native-k8s-operator.yaml
+++ b/deploy/flink-native-k8s-operator.yaml
@@ -30,8 +30,8 @@ spec:
           items:
           - key: flink-conf.yaml
             path: flink-conf.yaml
-          - key: log4j.properties
-            path: log4j.properties
+          - key: log4j-console.properties
+            path: log4j-console.properties
 
 ---
 
@@ -52,7 +52,7 @@ data:
     jobmanager.memory.process.size: 1600m
     taskmanager.memory.process.size: 1728m
     parallelism.default: 2
-  log4j.properties: |+
+  log4j-console.properties: |+
     # This affects logging for both user code and Flink
     rootLogger.level = INFO
     rootLogger.appenderRef.console.ref = ConsoleAppender

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <lombok.version>1.18.10</lombok.version>
 
         <scala.version>2.11</scala.version>
-        <flink.version>1.11-SNAPSHOT</flink.version>
+        <flink.version>1.12.3</flink.version>
 
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>2.13.3</log4j.version>


### PR DESCRIPTION
This PR fixs #4 

Flink 1.12 updated the log4j configuration file name. If we continue to use the `log4j.properties` here. The kubernetes logs will not be accessible.

Updating the name here will fix the issue.
[1] https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/deployment/resource-providers/native_kubernetes/#logging