### PR TITLE
Fix some errors in the two Fabric8io branch - Still don't work since Flink source code imcompatible issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8-jdk-slim-buster
 
-COPY target/flink-native-k8s-operator-1.0-SNAPSHOT.jar /
+COPY ./k8s-operator/target/k8s-operator-1.0-SNAPSHOT.jar /
 
-CMD ["java", "-jar", "/flink-native-k8s-operator-1.0-SNAPSHOT.jar"]
+CMD ["java", "-jar", "/k8s-operator-1.0-SNAPSHOT.jar"]

--- a/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/KubernetesOperatorEntrypoint.java
+++ b/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/KubernetesOperatorEntrypoint.java
@@ -1,5 +1,6 @@
 package org.apache.flink.kubernetes.operator;
 
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -51,15 +52,11 @@ public class KubernetesOperatorEntrypoint {
 
             final SharedInformerFactory informerFactory = k8sClient.informers();
 
-            final SharedIndexInformer<FlinkApplication> flinkAppinformer = informerFactory.sharedIndexInformerForCustomResource(
-            	crdContext,
-	            FlinkApplication.class,
-	            FlinkApplicationList.class,
-	            10 * 60 * 1000);
-			final MixedOperation<FlinkApplication, FlinkApplicationList, Resource<FlinkApplication>> flinkAppK8sClient =
-					(MixedOperation<FlinkApplication, FlinkApplicationList, Resource<FlinkApplication>>)
-							k8sClient.customResources(FlinkApplication.class, FlinkApplicationList.class)
-									.inNamespace(namespace);
+					final SharedIndexInformer<FlinkApplication> flinkAppinformer = informerFactory
+							.sharedIndexInformerForCustomResource(FlinkApplication.class, FlinkApplicationList.class, 10 * 60 * 1000);
+
+					MixedOperation<FlinkApplication, KubernetesResourceList<FlinkApplication>, Resource<FlinkApplication>>  flinkAppK8sClient =
+							k8sClient.customResources(FlinkApplication.class);
 
             FlinkApplicationController flinkApplicationController = new FlinkApplicationController(
 	            k8sClient,

--- a/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkApplicationController.java
+++ b/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkApplicationController.java
@@ -1,5 +1,6 @@
 package org.apache.flink.kubernetes.operator.controller;
 
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.HTTPIngressRuleValueBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
@@ -54,7 +55,7 @@ public class FlinkApplicationController {
     private static final int RECONCILE_INTERVAL_MS = 3000;
 
     private final KubernetesClient kubernetesClient;
-    private final MixedOperation<FlinkApplication, FlinkApplicationList, Resource<FlinkApplication>> flinkAppK8sClient;
+    private final MixedOperation<FlinkApplication, KubernetesResourceList<FlinkApplication>, Resource<FlinkApplication>> flinkAppK8sClient;
     private final SharedIndexInformer<FlinkApplication> flinkAppInformer;
     private final Lister<FlinkApplication> flinkClusterLister;
 
@@ -68,7 +69,7 @@ public class FlinkApplicationController {
 
     public FlinkApplicationController(
             KubernetesClient kubernetesClient,
-            MixedOperation<FlinkApplication, FlinkApplicationList, Resource<FlinkApplication>> flinkAppK8sClient,
+            MixedOperation<FlinkApplication, KubernetesResourceList<FlinkApplication>, Resource<FlinkApplication>> flinkAppK8sClient,
             SharedIndexInformer<FlinkApplication> flinkAppInformer,
             String namespace) {
         this.kubernetesClient = kubernetesClient;

--- a/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkApplication.java
+++ b/k8s-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkApplication.java
@@ -4,12 +4,19 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkApplicationSpec;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkApplicationStatus;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize()
+@Version(FlinkApplication.VERSION)
+@Group(FlinkApplication.GROUP)
 public class FlinkApplication extends CustomResource {
+    public static final String GROUP = "flink.k8s.io";
+    public static final String VERSION = "v1alpha1";
+
     private FlinkApplicationSpec spec;
     private FlinkApplicationStatus status;
 


### PR DESCRIPTION
Hello Yang, @wangyang0918 
I tried to use your `two-k8s-client-version` branch to do a test. After fixing the Dockerfile error, I still can't successful start the operator deployment because of the type cast you did in `KubernetesOperatorEntrypoint.java` . This will cause errors below.

```
flink-native-k8s-operator-84f4cd89c7-t8hzb   0/1     Completed   2          38s
[root@erpfintech-data-extraction-bastion-do-not-modify deploy]# kubectl logs -f flink-native-k8s-operator-84f4cd89c7-t8hzb -n operator
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2021-06-17 22:45:27,088 INFO  org.apache.flink.kubernetes.operator.KubernetesOperatorEntrypoint [] - Using namespace : operator
2021-06-17 22:45:27,328 ERROR org.apache.flink.kubernetes.operator.KubernetesOperatorEntrypoint [] - Kubernetes Client Exception :
io.fabric8.kubernetes.client.KubernetesClientException: An error has occurred.
	at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:64) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:53) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext.fromCustomResourceType(CustomResourceDefinitionContext.java:126) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.DefaultKubernetesClient.customResources(DefaultKubernetesClient.java:415) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.KubernetesOperatorEntrypoint.main(KubernetesOperatorEntrypoint.java:64) [k8s-operator-1.0-SNAPSHOT.jar:?]
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
	at io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext.fromCustomResourceType(CustomResourceDefinitionContext.java:116) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	... 2 more
Caused by: java.lang.IllegalArgumentException: org.apache.flink.kubernetes.operator.crd.FlinkApplication CustomResource must provide an API version using @io.fabric8.kubernetes.model.annotation.Group and @io.fabric8.kubernetes.model.annotation.Version annotations
	at io.fabric8.kubernetes.client.CustomResource.<init>(CustomResource.java:98) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.crd.FlinkApplication.<init>(FlinkApplication.java:14) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
	at io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext.fromCustomResourceType(CustomResourceDefinitionContext.java:116) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	... 2 more
```

As a result, I update the constructor to be v5.4.0 compatible and that content I changed during my test is shared in the PR.
With those changes, I can start the reconcile process.

However, it is impossible to submit a Flink Application Cluster to the operator since Flink is calling 4.9.2 Fabric8io APIs and it is totally imcompatible with 5.4.0 API.

I will encounter the errors like below. As you can see,  the error was thrown from Flink source code and that's something I can't control by modifying the operator code.

```
2021-06-17 23:06:15,176 INFO  org.apache.flink.client.deployment.application.cli.ApplicationClusterDeployer [] - Submitting application in 'Application Mode'.
2021-06-17 23:06:16,084 INFO  org.apache.flink.kubernetes.utils.KubernetesUtils            [] - The service account configured in pod template will be overwritten to 'flink-native-k8s-operator' because of explicitly configured options.
2021-06-17 23:06:16,253 WARN  org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - Failed to create the Kubernetes cluster "flink-demo", try to clean up the residual resources.
2021-06-17 23:06:16,254 INFO  org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - Failed to stop and clean up the Kubernetes cluster "flink-demo".
java.lang.IllegalStateException: No adapter available for type:class org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.AppsAPIGroupClient
	at org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.BaseClient.adapt(BaseClient.java:130) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.DefaultKubernetesClient.apps(DefaultKubernetesClient.java:306) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient.stopAndCleanupCluster(Fabric8FlinkKubeClient.java:197) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.KubernetesClusterDescriptor.deployClusterInternal(KubernetesClusterDescriptor.java:282) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.KubernetesClusterDescriptor.deployApplicationCluster(KubernetesClusterDescriptor.java:208) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.client.deployment.application.cli.ApplicationClusterDeployer.run(ApplicationClusterDeployer.java:67) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.controller.FlinkApplicationController.reconcile(FlinkApplicationController.java:202) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.controller.FlinkApplicationController.run(FlinkApplicationController.java:167) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.KubernetesOperatorEntrypoint.main(KubernetesOperatorEntrypoint.java:85) [k8s-operator-1.0-SNAPSHOT.jar:?]
2021-06-17 23:06:16,262 ERROR org.apache.flink.kubernetes.operator.controller.FlinkApplicationController [] - Failed to deploy cluster flink-demo, Exception: org.apache.flink.client.deployment.ClusterDeploymentException: Could not create Kubernetes cluster "flink-demo".
2021-06-17 23:06:16,554 ERROR org.apache.flink.kubernetes.operator.controller.FlinkApplicationController [] - Catch all potential exceptions during Flink application deployment/update here to avoid k8s watcher exec failure.
java.lang.ClassCastException: class io.fabric8.kubernetes.api.model.extensions.Ingress cannot be cast to class io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress (io.fabric8.kubernetes.api.model.extensions.Ingress and io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress are in unnamed module of loader 'app')
	at io.fabric8.kubernetes.client.handlers.networking.v1beta1.IngressHandler.edit(IngressHandler.java:25) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.acceptVisitors(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:355) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:293) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at io.fabric8.kubernetes.client.dsl.internal.NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.createOrReplace(NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java:66) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.controller.FlinkApplicationController.updateIngress(FlinkApplicationController.java:310) ~[k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.controller.FlinkApplicationController.reconcile(FlinkApplicationController.java:217) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.controller.FlinkApplicationController.run(FlinkApplicationController.java:167) [k8s-operator-1.0-SNAPSHOT.jar:?]
	at org.apache.flink.kubernetes.operator.KubernetesOperatorEntrypoint.main(KubernetesOperatorEntrypoint.java:85) [k8s-operator-1.0-SNAPSHOT.jar:?]
2021-06-17 23:06:16,555 INFO  org.apache.flink.kubernetes.operator.controller.FlinkApplicationController [] - Trying to get item from work queue
2021-06-17 23:06:16,555 INFO  org.apache.flink.kubernetes.operator.controller.FlinkApplicationController [] - Work queue is empty
```

One another thing to note is that, in the operator CRD with version `apiextensions.k8s.io/v1beta1`, we were using `flink.k8s.io` as group name for Flink CRD. This is forbidden now (`apiextensions.k8s.io/v1`) since Kubernetes have changed apiGroups ending with `k8s.io` to be reserved apiGroups. See https://github.com/kubernetes/enhancements/pull/1111


To summarize, I think the upgrade mentioned in Flink Jira https://issues.apache.org/jira/browse/FLINK-22933
is a necessary work.
